### PR TITLE
Add path pre-verification before saving

### DIFF
--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -547,14 +547,17 @@ again:
     }
     // else file-name specified in the entry is really a file to open...
 
-    std::string finalFilename = base::get_file_name(buf);
-    try {
-      base::verify_filename(finalFilename);
-    } catch (const std::exception& e) {
-      Alert::show("Error<<Invalid filename: \"%s\"<<%s||&Go back", finalFilename.c_str(), e.what());
+    if (m_type == FileSelectorType::Save)
+    {
+      std::string finalFilename = base::get_file_name(buf);
+      try {
+        base::verify_filename(finalFilename);
+      } catch (const std::exception& e) {
+        Alert::show("Error<<Invalid filename: \"%s\"<<%s||&Go back", finalFilename.c_str(), e.what());
 
-      setVisible(true);
-      goto again;
+        setVisible(true);
+        goto again;
+      }
     }
 
     // does it not have extension? ...we should add the extension
@@ -751,15 +754,17 @@ void FileSelector::onNewFolder()
     if (currentFolder) {
       std::string dirname = window.name()->text();
 
-      try {
-        // Also disallows the use of path separators in the folder name,
-        // technically it would be valid, but might be confusing for the user.
-        base::verify_filename(dirname);
-      } catch (const std::exception& e) {
-        Alert::show("Error<<Invalid folder name: \"%s\"<<%s||&OK", dirname.c_str(), e.what());
+      if (m_type == FileSelectorType::Save) {
+        try {
+          // Also disallows the use of path separators in the folder name,
+          // technically it would be valid, but might be confusing for the user.
+          base::verify_filename(dirname);
+        } catch (const std::exception& e) {
+          Alert::show("Error<<Invalid folder name: \"%s\"<<%s||&OK", dirname.c_str(), e.what());
 
-        setVisible(true);
-        return;
+          setVisible(true);
+          return;
+        }
       }
 
       // Create the new directory

--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -547,18 +547,19 @@ again:
     }
     // else file-name specified in the entry is really a file to open...
 
-    if (m_type == FileSelectorType::Save)
-    {
+#ifdef _WIN32
+    if (m_type == FileSelectorType::Save) {
       std::string finalFilename = base::get_file_name(buf);
-      try {
-        base::verify_filename(finalFilename);
-      } catch (const std::exception& e) {
-        Alert::show("Error<<Invalid filename: \"%s\"<<%s||&Go back", finalFilename.c_str(), e.what());
+      std::string fver = base::win32_verify_filename(finalFilename);
+      if (!fver.empty())
+      {
+        Alert::show("Error<<Invalid filename: \"%s\"<<%s||&Go back", finalFilename.c_str(), fver.c_str());
 
         setVisible(true);
         goto again;
       }
     }
+#endif
 
     // does it not have extension? ...we should add the extension
     // selected in the filetype combo-box
@@ -754,18 +755,18 @@ void FileSelector::onNewFolder()
     if (currentFolder) {
       std::string dirname = window.name()->text();
 
+#ifdef _WIN32
       if (m_type == FileSelectorType::Save) {
-        try {
-          // Also disallows the use of path separators in the folder name,
-          // technically it would be valid, but might be confusing for the user.
-          base::verify_filename(dirname);
-        } catch (const std::exception& e) {
-          Alert::show("Error<<Invalid folder name: \"%s\"<<%s||&OK", dirname.c_str(), e.what());
+        std::string fver = base::win32_verify_filename(dirname);
+        if (!fver.empty())
+        {
+          Alert::show("Error<<Invalid folder name: \"%s\"<<%s||&OK", dirname.c_str(), fver.c_str());
 
           setVisible(true);
           return;
         }
       }
+#endif
 
       // Create the new directory
       try {

--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -547,6 +547,16 @@ again:
     }
     // else file-name specified in the entry is really a file to open...
 
+    std::string finalFilename = base::get_file_name(buf);
+    try {
+      base::verify_filename(finalFilename);
+    } catch (const std::exception& e) {
+      Alert::show("Error<<Invalid filename: \"%s\"<<%s||&Go back", finalFilename.c_str(), e.what());
+
+      setVisible(true);
+      goto again;
+    }
+
     // does it not have extension? ...we should add the extension
     // selected in the filetype combo-box
     if (base::get_file_extension(buf).empty()) {
@@ -740,6 +750,17 @@ void FileSelector::onNewFolder()
     IFileItem* currentFolder = m_fileList->getCurrentFolder();
     if (currentFolder) {
       std::string dirname = window.name()->text();
+
+      try {
+        // Also disallows the use of path separators in the folder name,
+        // technically it would be valid, but might be confusing for the user.
+        base::verify_filename(dirname);
+      } catch (const std::exception& e) {
+        Alert::show("Error<<Invalid folder name: \"%s\"<<%s||&OK", dirname.c_str(), e.what());
+
+        setVisible(true);
+        return;
+      }
 
       // Create the new directory
       try {

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -244,11 +244,12 @@ int compare_filenames(const std::string& a, const std::string& b)
     return 1;
 }
 
+#ifdef _WIN32
 std::string win32_verify_filename(const std::string& filename)
 {
   // In general, _wfopen() would fail for most of these characters *except slashes and colon*,
   // but returning a meaningful error message to the user is always a nice practice.
-  const std::string invalidChars = "\\/:?\"<>|*";
+  const std::string invalidChars = ":?\"<>|*";
 
   for (const char c : filename) {
     if (invalidChars.find(c) != std::string::npos) {
@@ -258,26 +259,6 @@ std::string win32_verify_filename(const std::string& filename)
   }
   return {};
 }
-
-std::string posix_verify_filename(const std::string& filename)
-{
-  return filename.find('/') != std::string::npos
-    ? "The filename contains an invalid '/' character."
-    : std::string{};
-}
-
-void verify_filename(const std::string& filename)
-{
-  std::string err;
-  // In general, filenames with path separators would be appended just fine to the selected folder,
-  // but we'd rather not let user do that to avoid confusion.
-#ifdef _WIN32
-  err = win32_verify_filename(const_cast<std::string&>(filename));
-#else
-  err = posix_verify_filename(const_cast<std::string&>(filename));
 #endif
-  if (!err.empty())
-    throw std::runtime_error(err);
-}
 
 } // namespace base

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -1,5 +1,6 @@
-// Aseprite Base Library
-// Copyright (c) 2001-2016 David Capello
+// Base Library
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2026       LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -241,6 +242,42 @@ int compare_filenames(const std::string& a, const std::string& b)
     return -1;
   else
     return 1;
+}
+
+std::string win32_verify_filename(const std::string& filename)
+{
+  // In general, _wfopen() would fail for most of these characters *except slashes and colon*,
+  // but returning a meaningful error message to the user is always a nice practice.
+  const std::string invalidChars = "\\/:?\"<>|*";
+
+  for (const char c : filename) {
+    if (invalidChars.find(c) != std::string::npos) {
+      return "The filename contains an invalid '"
+        + std::string(1,c) + "' character.";
+    }
+  }
+  return {};
+}
+
+std::string posix_verify_filename(const std::string& filename)
+{
+  return filename.find('/') != std::string::npos
+    ? "The filename contains an invalid '/' character."
+    : std::string{};
+}
+
+void verify_filename(const std::string& filename)
+{
+  std::string err;
+  // In general, filenames with path separators would be appended just fine to the selected folder,
+  // but we'd rather not let user do that to avoid confusion.
+#ifdef _WIN32
+  err = win32_verify_filename(const_cast<std::string&>(filename));
+#else
+  err = posix_verify_filename(const_cast<std::string&>(filename));
+#endif
+  if (!err.empty())
+    throw std::runtime_error(err);
 }
 
 } // namespace base

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -1,5 +1,6 @@
-// Aseprite Base Library
-// Copyright (c) 2001-2016 David Capello
+// Base Library
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2026       LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -51,5 +52,9 @@ namespace base {
   bool has_file_extension(const std::string& filename, const std::string& csv_extensions);
 
   int compare_filenames(const std::string& a, const std::string& b);
+
+  // Does platform-specific filename pre-validation to avoid any unexpected edge-case
+  // behaviors caused by feeding garbage parameters to file APIs.
+  void verify_filename(const std::string& filename);
 
 }

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -53,8 +53,10 @@ namespace base {
 
   int compare_filenames(const std::string& a, const std::string& b);
 
+#ifdef _WIN32
   // Does platform-specific filename pre-validation to avoid any unexpected edge-case
   // behaviors caused by feeding garbage parameters to file APIs.
-  void verify_filename(const std::string& filename);
+  std::string win32_verify_filename(const std::string& filename);
+#endif
 
 }


### PR DESCRIPTION
Provides a meaningful error dialog to the user if something is wrong with the filename. Also anticipates any unexpected behaviors that may occur if feeding such unverified paths to fopen()/_wfopen() (like e.g. allowing filenames with ':' on Windows that ends up writing to an alternate NTFS stream which is confusing to the user and useless for LibreSprite use-case in general).
