### PR TITLE
Fix symetry on new documents

### DIFF
--- a/src/app/pref/preferences.cpp
+++ b/src/app/pref/preferences.cpp
@@ -168,7 +168,7 @@ void Preferences::serializeDocPref(const app::Document* doc, app::DocumentPrefer
       set_config_file(docConfigFileName(doc).c_str());
       specific_file = true;
     }
-    else // if (save)
+    else if (save)
       return;
   }
 


### PR DESCRIPTION
Return the functionality to setting the symmetry axes to the centre of the canvas when creating a new document

Closes #3