### PR TITLE
Potential fix for code scanning alert no. 1: Unsigned difference expression compared to zero

### DIFF
--- a/src/render/median_cut.h
+++ b/src/render/median_cut.h
@@ -245,7 +245,7 @@ namespace render {
             boxes.push(box2);
             return true;
           }
-          else if (totalPoints1-planePoints > 0) {
+          else if (totalPoints1 > planePoints) {
             Box box1(AxisSplitter::box1(*this, i-1));
             Box box2(AxisSplitter::box2(*this, i));
             box1.points = totalPoints1-planePoints;


### PR DESCRIPTION
Potential fix for [https://github.com/veritaware/Besprited/security/code-scanning/1](https://github.com/veritaware/Besprited/security/code-scanning/1)

In general, to fix this kind of issue you either (a) cast the unsigned subtraction to a signed type before comparing to zero, or (b) avoid subtracting before comparing, typically by rewriting the condition in an equivalent way that does not involve unsigned underflow. Here, the intent of the `else if (totalPoints1-planePoints > 0)` check is to see whether there were any points on the previous side (before adding the current `planePoints`), i.e., whether `totalPoints1 - planePoints` is non-zero. The value is then reused to set `box1.points` and `box2.points` using the same subtraction and addition.

The safest and most straightforward change without altering functionality is to compute the “previous” counts in a temporary signed variable, or better, compute and store the previous unsigned values without risking underflow. Algebraically, `totalPoints1 - planePoints > 0` is equivalent to `totalPoints1 > planePoints`. That avoids subtraction entirely and expresses the intended condition directly. For the assignments, we can also reuse existing `std::size_t` arithmetic that must be valid if that relation holds. So in `src/render/median_cut.h`, around line 248, replace the condition `else if (totalPoints1-planePoints > 0)` with `else if (totalPoints1 > planePoints)`. No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
