### PR TITLE
Potential fix for code scanning alert no. 2: Signed overflow check

### DIFF
--- a/src/app/tools/point_shape.cpp
+++ b/src/app/tools/point_shape.cpp
@@ -73,7 +73,7 @@ void PointShape::doInkHline(int x1, int y, int x2, ToolLoop* loop)
     if (x2 >= loop->getDstImage()->width())
       x2 = loop->getDstImage()->width()-1;
 
-    if (x2-x1+1 < 1)
+    if (x2 < x1)
       return;
 
     loop->getInk()->inkHline(x1, y, x2, loop);


### PR DESCRIPTION
Potential fix for [https://github.com/veritaware/Besprited/security/code-scanning/2](https://github.com/veritaware/Besprited/security/code-scanning/2)

In general, to fix this type of problem you avoid performing arithmetic on signed integers in a way that can overflow just to check ranges. Instead, you either (a) rearrange the expression into an equivalent one that cannot overflow, or (b) use a wider or unsigned type for the intermediate calculation.

Here, the intent of `if (x2-x1+1 < 1) return;` is simply to check if the resulting segment has non‑positive length; since `x1` and `x2` have already been clamped to `[0, width-1]`, the number of pixels is at least zero, and the test is logically equivalent to verifying that `x2 < x1`. We can rewrite the condition as `if (x2 < x1) return;`, which does not involve any potentially overflowing arithmetic and preserves the original behavior for all `int` values. No new headers or helper functions are needed.

Concretely, in `src/app/tools/point_shape.cpp`, in `PointShape::doInkHline`, replace the line `if (x2-x1+1 < 1)` with `if (x2 < x1)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
