### PR TITLE
Increase the redraw limiter rate

### DIFF
--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -180,7 +180,8 @@ void Manager::flipDisplay()
   if (!m_display)
     return;
 
-  // Frame-rate limiter: only flip at most 120 times per second
+  // Frame-rate limiter: we want to limit the number of flips to avoid
+  // consuming 100% CPU on too frequent document canvas redraws
   double currentTime = base::current_tick() / 1000.0; // Convert milliseconds to seconds
   double timeSinceLastFlip = currentTime - m_lastFlipTime;
   

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -193,7 +193,7 @@ namespace ui {
     // Frame-limited redraw mechanism
     bool m_redrawRequested;
     double m_lastFlipTime;
-    static constexpr double MIN_FRAME_INTERVAL = 1.0 / 120.0; // 120 FPS max
+    static constexpr double MIN_FRAME_INTERVAL = 1.0 / 720.0; // 720 FPS max
   };
 
 } // namespace ui


### PR DESCRIPTION
Increase the document canvas redraw limiter rate to 720Hz
(multiply of both 120 and 144 to coincide with common display refresh rates).