### PR TITLE
Disable V8 engine by default

### DIFF
--- a/.github/workflows/cmakeMacOs.yml
+++ b/.github/workflows/cmakeMacOs.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: install deps
       run: |
-        brew install gnutls freetype jpeg webp pixman sdl2 sdl2_image tinyxml2 libarchive v8 ninja zlib xmlto dylibbundler
+        brew install gnutls freetype jpeg webp pixman sdl2 sdl2_image tinyxml2 libarchive ninja zlib xmlto dylibbundler
     - name: git
       run: |
         git submodule update --init --recursive
@@ -61,13 +61,11 @@ jobs:
       run: |
         if [ "${{ steps.check_tag.outputs.has_tag }}" = "true" ]; then
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_V8_SANDBOX=ON \
             -DRELEASE_TAG=ON \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         else
           cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_V8_SANDBOX=ON \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         fi

--- a/.github/workflows/cmakeWin64.yml
+++ b/.github/workflows/cmakeWin64.yml
@@ -33,7 +33,6 @@ jobs:
           mingw-w64-x86_64-SDL2
           mingw-w64-x86_64-SDL2_image
           mingw-w64-x86_64-tinyxml2
-          mingw-w64-x86_64-v8
           mingw-w64-x86_64-zlib
           mingw-w64-x86_64-libarchive
     - uses: actions/checkout@v3
@@ -63,9 +62,9 @@ jobs:
         mkdir build
         cd build
         if [ "${{ steps.check_tag.outputs.has_tag }}" = "true" ]; then
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DUSE_V8_SANDBOX=ON -DRELEASE_TAG=ON ..
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DRELEASE_TAG=ON ..
         else
-          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DUSE_V8_SANDBOX=ON ..
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
         fi
         make -j 4
         cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(ENABLE_TESTS       "Enable the unit tests" off)
 option(FULLSCREEN_PLATFORM "Enable fullscreen by default" off)
 
 option(USE_SDL2_BACKEND "Use SDL2 backend" on)
+option(ENABLE_V8_SCRIPT_ENGINE "Enable V8 scripting engine support" off)
 option(USE_V8_SANDBOX "Use V8 Sandbox" off)
 
 ######################################################################
@@ -232,49 +233,54 @@ include_directories(${GIF_INCLUDE_DIRS})
 find_package(JPEG REQUIRED)
 include_directories(${JPEG_INCLUDE_DIRS})
 
-# v8
-find_package(V8 QUIET)
-if(V8_FOUND)
-  include_directories(${V8_INCLUDE_DIR})
-  add_definitions(-DSCRIPT_ENGINE_V8=1)
+set(SCRIPT_ENGINE_V8 0)
+if(ENABLE_V8_SCRIPT_ENGINE)
+  find_package(V8 QUIET)
+  if(V8_FOUND)
+    include_directories(${V8_INCLUDE_DIR})
+    set(SCRIPT_ENGINE_V8 1)
 
-  include(CheckCXXSourceRuns)
-  set(CMAKE_REQUIRED_LIBRARIES ${V8_LIBRARY} ${V8_LIBBASE_LIBRARY} ${V8_LIBPLATFORM_LIBRARY})
-  set(CMAKE_REQUIRED_INCLUDES ${V8_INCLUDE_DIR})
-  message(STATUS ${V8_POINTER_COMPRESSION_OUTPUT})
-  # Since V8_COMPRESS_POINTERS is not defined here, the resulting program would
-  # die if the system v8 library had enabled pointer compression.
-  check_cxx_source_runs("
-    #include <v8.h>
-    #include <libplatform/libplatform.h>
-    int main(void) {
-      v8::V8::InitializeICU();
-      static std::unique_ptr<v8::Platform> m_platform;
-      m_platform = v8::platform::NewDefaultPlatform();
-      v8::V8::InitializePlatform(m_platform.get());
-      v8::V8::Initialize();
-      return 0;
-    }
-	" DISABLE_POINTER_COMPRESSION)
+    include(CheckCXXSourceRuns)
+    set(CMAKE_REQUIRED_LIBRARIES ${V8_LIBRARY} ${V8_LIBBASE_LIBRARY} ${V8_LIBPLATFORM_LIBRARY})
+    set(CMAKE_REQUIRED_INCLUDES ${V8_INCLUDE_DIR})
+    message(STATUS ${V8_POINTER_COMPRESSION_OUTPUT})
+    # Since V8_COMPRESS_POINTERS is not defined here, the resulting program would
+    # die if the system v8 library had enabled pointer compression.
+    check_cxx_source_runs("
+      #include <v8.h>
+      #include <libplatform/libplatform.h>
+      int main(void) {
+        v8::V8::InitializeICU();
+        static std::unique_ptr<v8::Platform> m_platform;
+        m_platform = v8::platform::NewDefaultPlatform();
+        v8::V8::InitializePlatform(m_platform.get());
+        v8::V8::Initialize();
+        return 0;
+      }
+  	" DISABLE_POINTER_COMPRESSION)
 
-  # pointers compression doesn't work on 32bit machines
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    if(DISABLE_POINTER_COMPRESSION EQUAL 1)
-      message(STATUS "Disabling V8 pointer compression")
-    else()
-      message(STATUS "Enabling V8 pointer compression")
-      add_definitions(-DV8_COMPRESS_POINTERS)
+    # pointers compression doesn't work on 32bit machines
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      if(DISABLE_POINTER_COMPRESSION EQUAL 1)
+        message(STATUS "Disabling V8 pointer compression")
+      else()
+        message(STATUS "Enabling V8 pointer compression")
+        add_definitions(-DV8_COMPRESS_POINTERS)
+      endif()
     endif()
-  endif()
 
-  if (USE_V8_SANDBOX)
-    add_definitions(-DV8_ENABLE_SANDBOX)
-  endif()
+    if (USE_V8_SANDBOX)
+      add_definitions(-DV8_ENABLE_SANDBOX)
+    endif()
 
-  message(STATUS "Optional V8 library found. Enabling V8 scripting engine.")
+    message(STATUS "V8 library found. Enabling V8 scripting engine.")
+  else()
+    message(STATUS "ENABLE_V8_SCRIPT_ENGINE is ON, but V8 was not found. Disabling V8 scripting engine.")
+  endif()
 else()
-  message(STATUS "Optional V8 library NOT found. Disabling V8 scripting engine.")
+  message(STATUS "V8 scripting engine is disabled (ENABLE_V8_SCRIPT_ENGINE=OFF).")
 endif()
+add_definitions(-DSCRIPT_ENGINE_V8=${SCRIPT_ENGINE_V8})
 
 
 find_package(CURL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Feel free to contribute to the project! Check out the [contributing guidelines](
 Follow the [installation guide](INSTALL.md).
 
 ## Theming
-The app is compatible with LibreSprite themes you can find [here](https://libresprite.github.io/#!/resources). 
+The app is compatible with LibreSprite themes you can find [here](https://libresprite.github.io/#!/resources).
+
+## Scripting
+The LibreSprite script compatibility is disabled by default due to current V8 library versioning isue that breaks GitHub workflows.
+If you need to run LibreSprite JS scripts, compile the project with the `-DENABLE_V8_SCRIPT_ENGINE=ON`.
 
 ## License
 This program is distributed under the [GNU General Public License Version 2](LICENSE.txt).

--- a/src/app/app_menus.cpp
+++ b/src/app/app_menus.cpp
@@ -127,6 +127,11 @@ void AppMenus::loadMenus(tinyxml2::XMLHandle& handle)
         .FirstChildElement("menus")
         .FirstChildElement("menu").ToElement();
     for (; xmlMenu; xmlMenu = xmlMenu->NextSiblingElement()) {
+#if !SCRIPT_ENGINE_V8
+        const char* id = xmlMenu->Attribute("id");
+        if (id && std::strcmp(id, "script_list") == 0)
+          continue;
+#endif
         auto menu = convertXmlelemToMenu(xmlMenu);
         if ( menu->id().empty()) {
             delete menu;
@@ -148,6 +153,15 @@ Menu* AppMenus::convertXmlelemToMenu(tinyxml2::XMLElement* elem)
 
   tinyxml2::XMLElement* child = elem->FirstChildElement();
   while (child) {
+#if !SCRIPT_ENGINE_V8
+    if (std::strcmp(child->Value(), "menu") == 0) {
+      const char* id = child->Attribute("id");
+      if (id && std::strcmp(id, "script_list") == 0) {
+        child = child->NextSiblingElement();
+        continue;
+      }
+    }
+#endif
     Widget* menuitem = convertXmlelemToMenuitem(child);
     if (menuitem)
       menu->addChild(menuitem);

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -19,10 +19,15 @@ else()
 endif()
 
 add_library(duktape ${DUKTAPE_DIR}/duktape.c)
-add_library(script-lib
+set(SCRIPT_LIB_SOURCES
   duktape/engine.cpp
-  v8/engine.cpp
   cout_delegate.cpp)
+
+if(SCRIPT_ENGINE_V8)
+  list(APPEND SCRIPT_LIB_SOURCES v8/engine.cpp)
+endif()
+
+add_library(script-lib ${SCRIPT_LIB_SOURCES})
 
 if(UNIX)
   target_link_libraries(duktape m)


### PR DESCRIPTION
Also hides the Scripts menu when V8 is disabled
(duktape being an available option is ignored currently)

This will act as a workaround for the issue with incompatible V8 library versions across different platforms in GitHub workflows

Closes #49 