### PR TITLE
Fix font alignment for the 'Add Text' tool

### DIFF
--- a/src/app/util/freetype_utils.cpp
+++ b/src/app/util/freetype_utils.cpp
@@ -49,11 +49,11 @@ doc::Image* render_text(const std::string& fontfile, int fontsize,
       face.forEachGlyph(
         text,
         [&bounds, &image, color, antialias](const ft::Glyph& glyph) {
-          int t, yimg = - bounds.y + int(glyph.y);
+          int t, yimg = - bounds.y + int(glyph.y + glyph.offsetY);
 
           for (int v=0; v<int(glyph.bitmap->rows); ++v, ++yimg) {
             const uint8_t* p = glyph.bitmap->buffer + v*glyph.bitmap->pitch;
-            int ximg = - bounds.x + int(glyph.x);
+            int ximg = - bounds.x + int(glyph.x + glyph.bearingX);
             int bit = 0;
 
             for (int u=0; u<int(glyph.bitmap->width); ++u, ++ximg) {

--- a/src/ft/face.h
+++ b/src/ft/face.h
@@ -148,8 +148,8 @@ namespace ft {
       gfx::Rect bounds(0, 0, 0, 0);
 
       forEachGlyph(str, [&](Glyph& glyph) {
-        bounds |= gfx::Rect(int(glyph.x),
-                            int(glyph.y),
+        bounds |= gfx::Rect(int(glyph.x + glyph.bearingX),
+                            int(glyph.y + glyph.offsetY),
                             glyph.ft_glyph->advance.x / double(1 << 16),
                             glyph.bitmap->rows);
       });


### PR DESCRIPTION
Character glyphs in the textline were incorrectly aligned to the top when generating font previews in the 'Add Text' menu and in the pasted text bitmap.

This commit fixes the glyph positioning in both the render_text() function and the calcTextBounds() helper function accordingly to how the glyph positioning is handled in `src/she/common/generic_surface.h`.

Fixes #18