### PR TITLE
Add 100%/Center/Fit Screen zoom tool options

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,5 +1,6 @@
-# Aseprite     | Copyright (C) 2001-2016  David Capello
-# LibreSprite  | Copyright (C)      2021  LibreSprite contributors
+# Aseprite    | Copyright (C) 2001-2016 David Capello
+# LibreSprite | Copyright (C) 2021      LibreSprite contributors
+# Besprited   | Copyright (C) 2026      Veritaware
 
 # Generate a ui::Widget for each widget in a XML file
 file(GLOB widget_files ${CMAKE_SOURCE_DIR}/data/widgets/*.xml)
@@ -198,6 +199,7 @@ add_library(app-lib
   commands/cmd_exit.cpp
   commands/cmd_export_sprite_sheet.cpp
   commands/cmd_eyedropper.cpp
+  commands/cmd_fit_screen.cpp
   commands/cmd_flatten_layers.cpp
   commands/cmd_flip.cpp
   commands/cmd_frame_properties.cpp

--- a/src/app/commands/cmd_fit_screen.cpp
+++ b/src/app/commands/cmd_fit_screen.cpp
@@ -1,0 +1,72 @@
+// Besprited | Copyright (C) 2026 Veritaware
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "app/app.h"
+#include "app/commands/command.h"
+#include "app/modules/editors.h"
+#include "app/ui/editor/editor.h"
+#include "doc/sprite.h"
+#include "render/zoom.h"
+#include "ui/view.h"
+
+#include <algorithm>
+
+namespace app {
+
+class FitScreenCommand : public Command {
+public:
+  FitScreenCommand();
+  Command* clone() const override { return new FitScreenCommand(*this); }
+
+protected:
+  bool onEnabled(Context* context) override;
+  void onExecute(Context* context) override;
+};
+
+FitScreenCommand::FitScreenCommand()
+  : Command("FitScreen",
+            "Fit Screen",
+            CmdUIOnlyFlag)
+{
+}
+
+bool FitScreenCommand::onEnabled(Context* context)
+{
+  return (current_editor != NULL && current_editor->sprite() != NULL);
+}
+
+void FitScreenCommand::onExecute(Context* context)
+{
+  Editor* editor = current_editor;
+  doc::Sprite* sprite = editor->sprite();
+  if (!sprite)
+    return;
+
+  ui::View* view = ui::View::getView(editor);
+  gfx::Rect vp = view->viewportBounds();
+
+  double scaleX = vp.w / (double)sprite->width();
+  double scaleY = vp.h / (double)sprite->height();
+  double scale = std::min(scaleX, scaleY);
+
+  render::Zoom zoom = render::Zoom::fromScale(scale);
+
+  editor->setZoomAndCenterInMouse(
+    zoom,
+    gfx::Point(vp.x + vp.w/2, vp.y + vp.h/2),
+    Editor::ZoomBehavior::CENTER);
+}
+
+Command* CommandFactory::createFitScreenCommand()
+{
+  return new FitScreenCommand;
+}
+
+} // namespace app

--- a/src/app/commands/commands_list.h
+++ b/src/app/commands/commands_list.h
@@ -1,6 +1,6 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
-// Copyright (C) 2021-2025  LibreSprite contributors
+// Aseprite    | Copyright (C) 2001-2016 David Capello
+// LibreSprite | Copyright (C) 2021-2025 LibreSprite contributors
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -42,6 +42,7 @@ FOR_EACH_COMMAND(DuplicateView)
 FOR_EACH_COMMAND(Exit)
 FOR_EACH_COMMAND(ExportSpriteSheet)
 FOR_EACH_COMMAND(Eyedropper)
+FOR_EACH_COMMAND(FitScreen)
 FOR_EACH_COMMAND(FlattenLayers)
 FOR_EACH_COMMAND(Flip)
 FOR_EACH_COMMAND(FrameProperties)

--- a/src/app/ui/context_bar.cpp
+++ b/src/app/ui/context_bar.cpp
@@ -1,5 +1,6 @@
-// Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C) 2021       LibreSprite contributors
+// Aseprite    | Copyright (C) 2001-2016 David Capello
+// LibreSprite | Copyright (C) 2021      LibreSprite contributors
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -15,7 +16,9 @@
 #include "app/app_brushes.h"
 #include "app/app_menus.h"
 #include "app/color_utils.h"
+#include "app/commands/command.h"
 #include "app/commands/commands.h"
+#include "app/commands/params.h"
 #include "app/document.h"
 #include "app/ini_file.h"
 #include "app/modules/gfx.h"
@@ -1317,6 +1320,48 @@ private:
   }
 };
 
+class ContextBar::ZoomOptionsField : public ButtonSet {
+public:
+  ZoomOptionsField() : ButtonSet(3) {
+    addItem("100%");
+    addItem("Center");
+    addItem("Fit Screen");
+    setOfferCapture(false);
+  }
+
+  void setupTooltips(TooltipManager* tooltipManager) {
+    tooltipManager->addTooltipFor(at(0), "Set zoom to 100%", BOTTOM);
+    tooltipManager->addTooltipFor(at(1), "Center view on sprite", BOTTOM);
+    tooltipManager->addTooltipFor(at(2), "Fit sprite in the screen", BOTTOM);
+  }
+
+protected:
+  void onItemChange(Item* item) override {
+    ButtonSet::onItemChange(item);
+
+    switch (selectedItem()) {
+      case 0: {
+        Params params;
+        params.set("percentage", "100");
+        UIContext::instance()->executeCommand(
+          CommandsModule::instance()->getCommandByName(CommandId::Zoom),
+          params);
+        UIContext::instance()->executeCommand(CommandId::ScrollCenter);
+        break;
+      }
+      case 1:
+        UIContext::instance()->executeCommand(CommandId::ScrollCenter);
+        break;
+      case 2:
+        UIContext::instance()->executeCommand(CommandId::FitScreen);
+        UIContext::instance()->executeCommand(CommandId::ScrollCenter);
+        break;
+    }
+
+    deselectItems();
+  }
+};
+
 ContextBar::ContextBar()
   : Box(HORIZONTAL)
 {
@@ -1379,6 +1424,9 @@ ContextBar::ContextBar()
   addChild(m_symmetry = new SymmetryField());
   m_symmetry->setVisible(Preferences::instance().symmetryMode.enabled());
 
+  addChild(m_zoomOptions = new ZoomOptionsField());
+  m_zoomOptions->setVisible(false);
+
   TooltipManager* tooltipManager = new TooltipManager();
   addChild(tooltipManager);
 
@@ -1401,6 +1449,7 @@ ContextBar::ContextBar()
   m_dropPixels->setupTooltips(tooltipManager);
   m_freehandAlgo->setupTooltips(tooltipManager);
   m_symmetry->setupTooltips(tooltipManager);
+  m_zoomOptions->setupTooltips(tooltipManager);
 
   App::instance()->activeToolManager()->addObserver(this);
 
@@ -1627,6 +1676,11 @@ void ContextBar::updateForTool(tools::Tool* tool)
     (tool->getController(0)->isFreehand() ||
      tool->getController(1)->isFreehand());
 
+  // True if the current tool is the zoom tool.
+  bool isZoom = tool &&
+    (tool->getInk(0)->isZoom() ||
+     tool->getInk(1)->isZoom());
+
   bool showOpacity =
     (supportOpacity) &&
     ((isPaint && (hasInkWithOpacity || hasImageBrush)) ||
@@ -1654,6 +1708,7 @@ void ContextBar::updateForTool(tools::Tool* tool)
   m_pivot->setVisible(true);
   m_dropPixels->setVisible(false);
   m_selectBoxHelp->setVisible(false);
+  m_zoomOptions->setVisible(isZoom);
 
   m_symmetry->setVisible(
     Preferences::instance().symmetryMode.enabled() &&

--- a/src/app/ui/context_bar.h
+++ b/src/app/ui/context_bar.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016 David Capello
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -106,6 +106,7 @@ namespace app {
     class DropPixelsField;
     class AutoSelectLayerField;
     class SymmetryField;
+    class ZoomOptionsField;
 
     BrushTypeField* m_brushType;
     BrushAngleField* m_brushAngle;
@@ -136,6 +137,7 @@ namespace app {
     doc::BrushRef m_activeBrush;
     ui::Label* m_selectBoxHelp;
     SymmetryField* m_symmetry;
+    ZoomOptionsField* m_zoomOptions;
     base::ScopedConnection m_sizeConn;
     base::ScopedConnection m_angleConn;
     base::ScopedConnection m_opacityConn;


### PR DESCRIPTION
Adds the three zoom tool option buttons (100%, Center, Fit Screen) to the context bar when the Zoom tool is selected, matching Aseprite/LibreSprite behavior.

- Added a `ZoomOptionsField` (ButtonSet) to the context bar, visible only when the Zoom tool is active.
- "100%" uses the existing `Zoom` command, "Center" uses the existing `ScrollCenter` command.
- Added a new `FitScreenCommand` that fits the whole sprite in the viewport and centers it.

Fixes #45