### PR TITLE
Fix graphical glitch when opening preferences with custom checker size

### DIFF
--- a/src/app/commands/cmd_options.cpp
+++ b/src/app/commands/cmd_options.cpp
@@ -540,7 +540,8 @@ private:
     m_checked_bg_width->setVisible(isCustom);
     m_checked_bg_height->setVisible(isCustom);
 
-    layout();
+    if (isVisible())
+      layout();
   }
 
   static std::string userThemeFolder() {


### PR DESCRIPTION
Fixes a graphical glitch where the top-right part of the Preferences window was rendered incorrectly (a duplicated rectangle) when the Custom checked background size was selected and the Preferences dialog was opened.

## Root cause
`onBgTypeChange()` calls `layout()` whenever the checked background size combobox changes. This handler also fires during `OptionsWindow`'s construction, because `onChangeGridScope()` programmatically sets the combobox's initial selection, which triggers the connected `Change` signal before the window has been remapped/shown (i.e. before it has final bounds). Calling `layout()` at that point invalidates a stale region, leaving a duplicated rectangle once the window is actually opened.

## Fix
Guard the `layout()` call in `onBgTypeChange()` with `isVisible()`, matching an existing pattern used elsewhere in the codebase, so it only runs once the window is actually on screen.

Fixes #91

Generated with [Claude Code](https://claude.ai/code)