### PR TITLE
Increase max brush size limit to 256px

### DIFF
--- a/src/doc/brush.h
+++ b/src/doc/brush.h
@@ -1,6 +1,6 @@
-// Aseprite Document Library
-// Copyright (c) 2001-2016 David Capello
-// Besprited | Copyright (C) 2026 Veritaware
+// Document Library
+// Aseprite  | Copyright (C) 2001-2016 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/src/doc/brush.h
+++ b/src/doc/brush.h
@@ -1,5 +1,6 @@
 // Aseprite Document Library
 // Copyright (c) 2001-2016 David Capello
+// Besprited | Copyright (C) 2026 Veritaware
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -20,7 +21,7 @@ namespace doc {
   class Brush {
   public:
     static const int kMinBrushSize = 1;
-    static const int kMaxBrushSize = 64;
+    static const int kMaxBrushSize = 256;
 
     enum class ImageColor { MainColor, BackgroundColor };
 


### PR DESCRIPTION
## Summary
- Increases the brush size cap from 64px to 256px by updating `doc::Brush::kMaxBrushSize` in `src/doc/brush.h`, which drives the context bar spinner and the increase/decrease brush size commands.

Fixes #97

🤖 Generated with [Claude Code](https://claude.ai/code)