### PR TITLE
Add keyboard shortcut to toggle Tiled Mode

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -113,6 +113,7 @@
       <key command="ShowGrid" shortcut="Shift+G" />
       <key command="ShowPixelGrid" shortcut="Alt+Shift+G" />
       <key command="SnapToGrid" shortcut="Shift+S" />
+      <key command="TiledMode" shortcut="Shift+T"><param name="axis" value="both" /></key>
       <key command="SetLoopSection" shortcut="F2" />
       <key command="ShowOnionSkin" shortcut="F3" />
       <key command="Timeline" shortcut="Tab" label="TIME">

--- a/src/app/commands/cmd_tiled_mode.cpp
+++ b/src/app/commands/cmd_tiled_mode.cpp
@@ -1,5 +1,5 @@
-// Aseprite    | Copyright (C) 2001-2015 David Capello
-// Besprited   | Copyright (C) 2026      Veritaware
+// Aseprite  | Copyright (C) 2001-2015 David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/commands/cmd_tiled_mode.cpp
+++ b/src/app/commands/cmd_tiled_mode.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015 David Capello
+// Besprited   | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -65,7 +65,8 @@ bool TiledModeCommand::onChecked(Context* ctx)
 void TiledModeCommand::onExecute(Context* ctx)
 {
   const Document* doc = ctx->activeDocument();
-  Preferences::instance().document(doc).tiled.mode(m_mode);
+  auto& tiled = Preferences::instance().document(doc).tiled;
+  tiled.mode(tiled.mode() == m_mode ? filters::TiledMode::NONE : m_mode);
 }
 
 Command* CommandFactory::createTiledModeCommand()


### PR DESCRIPTION
## Summary
- Bind `Shift+T` to toggle Tiled Mode between None and Both Axes, via the existing `TiledMode` command with `axis="both"`.
- `TiledModeCommand::onExecute` now toggles back to `NONE` when the requested mode is already active, so the shortcut behaves as a toggle.

Fixes #101

Generated with [Claude Code](https://claude.ai/code)