### PR TITLE
Make 'size from Clipboard' canvas size optional

### DIFF
--- a/data/widgets/new_sprite.xml
+++ b/data/widgets/new_sprite.xml
@@ -11,6 +11,10 @@
         <label text="Height:" />
         <entry id="height" maxsize="32" cell_align="horizontal" suffix="px" />
       </grid>
+      <box horizontal="true">
+        <box horizontal="true" expansive="true" />
+        <button id="size_from_clipboard" text="Size from Clipboard" />
+      </box>
 
       <separator text="Color Mode:" left="true" horizontal="true" />
       <buttonset columns="3" id="color_mode">
@@ -25,6 +29,8 @@
         <item text="&amp;White" icon="icon_white" />
         <item text="&amp;Black" icon="icon_black" />
       </buttonset>
+
+      <check id="paste_as_layer" text="Paste clipboard image as new layer" />
 
       <box horizontal="true">
         <box horizontal="true" expansive="true" />

--- a/src/app/commands/cmd_new_file.cpp
+++ b/src/app/commands/cmd_new_file.cpp
@@ -1,5 +1,6 @@
 // Aseprite
 // Copyright (C) 2001-2015  David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -28,6 +29,7 @@
 #include "doc/palette.h"
 #include "doc/primitives.h"
 #include "doc/sprite.h"
+#include "render/quantization.h"
 #include "ui/ui.h"
 
 #include "new_sprite.xml.h"
@@ -81,18 +83,12 @@ void NewFileCommand::onExecute(Context* context)
       format != IMAGE_GRAYSCALE) {
     format = IMAGE_INDEXED;
   }
+  // Default size is always the last size used by the user, regardless
+  // of what's currently in the clipboard.
   int w = pref.newFile.width();
   int h = pref.newFile.height();
   int bg = pref.newFile.backgroundColor();
   bg = MID(0, bg, 2);
-
-  // If the clipboard contains an image, we can show the size of the
-  // clipboard as default image size.
-  gfx::Size clipboardSize;
-  if (clipboard::get_image_size(clipboardSize)) {
-    w = clipboardSize.w;
-    h = clipboardSize.h;
-  }
 
   window.width()->setTextf("%d", MAX(1, w));
   window.height()->setTextf("%d", MAX(1, h));
@@ -102,6 +98,23 @@ void NewFileCommand::onExecute(Context* context)
 
   // Select background color
   window.bgColor()->setSelectedItem(bg);
+
+  // If the clipboard contains an image, offer the user a way to fill
+  // the size fields with the clipboard image's size, and to paste
+  // that image as the sprite's first layer. Otherwise, hide both
+  // controls since they wouldn't do anything.
+  gfx::Size clipboardSize;
+  bool hasClipboardImage = clipboard::get_image_size(clipboardSize);
+  window.sizeFromClipboard()->setVisible(hasClipboardImage);
+  window.pasteAsLayer()->setVisible(hasClipboardImage);
+
+  if (hasClipboardImage) {
+    window.sizeFromClipboard()->Click.connect(
+      [&window, clipboardSize](ui::Event&) {
+        window.width()->setTextf("%d", MAX(1, clipboardSize.w));
+        window.height()->setTextf("%d", MAX(1, clipboardSize.h));
+      });
+  }
 
   // Open the window
   window.openWindowInForeground();
@@ -170,6 +183,43 @@ void NewFileCommand::onExecute(Context* context)
                 sprite->transparentColor())));
 
           set_current_palette(oldPal.get(), false);
+        }
+      }
+
+      // Optionally paste the clipboard image into the new sprite as
+      // its first layer.
+      if (hasClipboardImage && window.pasteAsLayer()->isSelected()) {
+        std::shared_ptr<Image> clipImage;
+        std::shared_ptr<Palette> clipPalette;
+
+        if (clipboard::get_image(clipImage, clipPalette)) {
+          Layer* layer = sprite->folder()->getFirstLayer();
+
+          if (layer && layer->isImage()) {
+            LayerImage* layerImage = static_cast<LayerImage*>(layer);
+            Image* dstImage = layerImage->cel(frame_t(0))->image();
+            Palette* dstPalette = sprite->palette(frame_t(0));
+
+            std::shared_ptr<Image> srcImage;
+            if (clipImage->pixelFormat() == sprite->pixelFormat() &&
+                // Indexed images can be copied directly only if both
+                // images have the same palette.
+                (clipImage->pixelFormat() != IMAGE_INDEXED ||
+                 clipPalette->countDiff(*dstPalette, nullptr, nullptr) == 0)) {
+              srcImage = clipImage;
+            }
+            else {
+              srcImage.reset(
+                render::convert_pixel_format(
+                  clipImage.get(), nullptr, sprite->pixelFormat(),
+                  DitheringMethod::NONE, sprite->rgbMap(frame_t(0)),
+                  clipPalette.get(),
+                  layerImage->isBackground(),
+                  0));
+            }
+
+            doc::copy_image(dstImage, srcImage.get());
+          }
         }
       }
 

--- a/src/app/commands/cmd_new_file.cpp
+++ b/src/app/commands/cmd_new_file.cpp
@@ -219,6 +219,15 @@ void NewFileCommand::onExecute(Context* context)
             }
 
             doc::copy_image(dstImage, srcImage.get());
+
+            // The pasted image becomes the sprite's background, so
+            // rename its layer and add a fresh empty layer above it
+            // for the user to draw on.
+            layerImage->setName("Background");
+
+            std::unique_ptr<LayerImage> topLayer(new LayerImage(sprite.get()));
+            topLayer->setName("Layer 1");
+            sprite->folder()->addLayer(topLayer.release());
           }
         }
       }

--- a/src/app/commands/cmd_new_file.cpp
+++ b/src/app/commands/cmd_new_file.cpp
@@ -1,5 +1,4 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite  | Copyright (C) 2001-2015 David Capello
 // Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
@@ -104,7 +103,7 @@ void NewFileCommand::onExecute(Context* context)
   // that image as the sprite's first layer. Otherwise, hide both
   // controls since they wouldn't do anything.
   gfx::Size clipboardSize;
-  bool hasClipboardImage = clipboard::get_image_size(clipboardSize);
+  const bool hasClipboardImage = clipboard::get_image_size(clipboardSize);
   window.sizeFromClipboard()->setVisible(hasClipboardImage);
   window.pasteAsLayer()->setVisible(hasClipboardImage);
 

--- a/src/app/commands/cmd_new_file.cpp
+++ b/src/app/commands/cmd_new_file.cpp
@@ -188,6 +188,7 @@ void NewFileCommand::onExecute(Context* context)
 
       // Optionally paste the clipboard image into the new sprite as
       // its first layer.
+      Layer* newTopLayer = nullptr;
       if (hasClipboardImage && window.pasteAsLayer()->isSelected()) {
         std::shared_ptr<Image> clipImage;
         std::shared_ptr<Palette> clipPalette;
@@ -227,16 +228,28 @@ void NewFileCommand::onExecute(Context* context)
 
             std::unique_ptr<LayerImage> topLayer(new LayerImage(sprite.get()));
             topLayer->setName("Layer 1");
+            newTopLayer = topLayer.get();
             sprite->folder()->addLayer(topLayer.release());
           }
         }
       }
 
       // Show the sprite to the user
+      Sprite* spritePtr = sprite.get();
       std::unique_ptr<Document> doc(new Document(sprite.get()));
       sprite.release();
       snprintf(buf, sizeof(buf), "Sprite-%04d", ++_sprite_counter);
       doc->setFilename(buf);
+
+      // If we added an empty layer above the pasted clipboard image,
+      // make it the active layer instead of the "Background" layer
+      // below it. This must happen before setContext(), since that's
+      // what creates the editor view for the document.
+      if (newTopLayer) {
+        Preferences::instance().document(doc.get()).site.layer(
+          spritePtr->layerToIndex(newTopLayer));
+      }
+
       doc->setContext(context);
       doc.release();
     }

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -1,5 +1,6 @@
 // Aseprite
 // Copyright (C) 2001-2016  David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -157,6 +158,18 @@ static void set_clipboard_image(Image* image,
   clipboard_range.invalidate();
 }
 
+// Refreshes clipboard_image/clipboard_palette from the native (OS)
+// clipboard, if it currently holds a bitmap.
+static void load_native_clipboard_bitmap()
+{
+  Image* native_image = nullptr;
+  Mask* native_mask = nullptr;
+  std::shared_ptr<Palette> native_palette;
+  get_native_clipboard_bitmap(&native_image, &native_mask, native_palette);
+  if (native_image)
+    set_clipboard_image(native_image, native_mask, native_palette, false, false);
+}
+
 static bool copy_from_document(const Site& site, bool merged = false)
 {
   const app::Document* document = static_cast<const app::Document*>(site.document());
@@ -303,14 +316,7 @@ void paste()
 
     case clipboard::ClipboardImage: {
       // Get the image from the clipboard.
-      {
-        Image* native_image = nullptr;
-        Mask* native_mask = nullptr;
-        std::shared_ptr<Palette> native_palette;
-        get_native_clipboard_bitmap(&native_image, &native_mask, native_palette);
-        if (native_image)
-          set_clipboard_image(native_image, native_mask, native_palette, false, false);
-      }
+      load_native_clipboard_bitmap();
 
       if (!clipboard_image)
         return;
@@ -555,6 +561,21 @@ bool get_image_size(gfx::Size& size)
 #endif
 
   return false;
+}
+
+bool get_image(std::shared_ptr<Image>& image, std::shared_ptr<Palette>& palette)
+{
+  if (get_current_format() != ClipboardImage)
+    return false;
+
+  load_native_clipboard_bitmap();
+
+  if (!clipboard_image)
+    return false;
+
+  image = clipboard_image;
+  palette = clipboard_palette;
+  return true;
 }
 
 Palette* get_palette()

--- a/src/app/util/clipboard.cpp
+++ b/src/app/util/clipboard.cpp
@@ -1,5 +1,4 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite  | Copyright (C) 2001-2016 David Capello
 // Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify

--- a/src/app/util/clipboard.h
+++ b/src/app/util/clipboard.h
@@ -1,5 +1,6 @@
 // Aseprite
 // Copyright (C) 2001-2016  David Capello
+// Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -10,6 +11,8 @@
 #include "gfx/point.h"
 #include "gfx/size.h"
 #include "ui/base.h"
+
+#include <memory>
 
 namespace doc {
   class Image;
@@ -60,6 +63,11 @@ namespace app {
     // size in the clipboard, or return false in case that the clipboard
     // doesn't contain an image at all.
     bool get_image_size(gfx::Size& size);
+
+    // Returns true and fills "image" and "palette" with the clipboard's
+    // image and its palette, or returns false if the clipboard doesn't
+    // contain an image.
+    bool get_image(std::shared_ptr<Image>& image, std::shared_ptr<Palette>& palette);
 
     Palette* get_palette();
     const PalettePicks& get_palette_picks();

--- a/src/app/util/clipboard.h
+++ b/src/app/util/clipboard.h
@@ -1,5 +1,4 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite  | Copyright (C) 2001-2016 David Capello
 // Besprited | Copyright (C) 2026      Veritaware
 //
 // This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
The New Sprite dialog previously overwrote the remembered width/height with the clipboard image's size whenever an image was on the clipboard, with no way to keep the last manually entered size.

This implements the simplified approach from the issue discussion:
- The dialog always defaults width/height to the last-used values.
- A "Size from Clipboard" button appears below the size fields when the clipboard has an image, to explicitly fill in its size.
- A "Paste clipboard image as new layer" checkbox appears to seed the new sprite with the clipboard image.

Fixes #106

Generated with [Claude Code](https://claude.ai/code)