### PR TITLE
Install full build deps in claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,8 +31,11 @@ jobs:
           fetch-depth: 1
           submodules: recursive
 
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake build-essential
+      - name: Prepare environment and install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ libcurl4-gnutls-dev libfreetype6-dev libgif-dev libgtest-dev libjpeg-dev libpixman-1-dev libpng-dev libsdl2-dev libsdl2-image-dev libtinyxml2-dev libwebp-dev libx11-dev libxcursor-dev ninja-build libnode-dev zlib1g-dev libarchive-dev libfuse2
+          pip install cmake
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
Mirror the "Prepare environment and install dependencies" step from cmakeLinux.yml so the Claude Code job has the packages it needs to actually build besprited, instead of the minimal ninja/cmake/ build-essential set which was missing several required libs.

NO_SW_CHANGE